### PR TITLE
refactor(slider): remove the repetitions of function calls

### DIFF
--- a/src/js/plugins/slider.js
+++ b/src/js/plugins/slider.js
@@ -1,6 +1,6 @@
 import Flickity from 'flickity';
 
-const generellSliderSettings = {
+const generalSliderSettings = {
   arrowShape:
     // eslint-disable-next-line max-len
     'M32.46,49.85,58.52,16a2.58,2.58,0,0,0,0-3,1.38,1.38,0,0,0-2.31,0L29,48.35a2.58,2.58,0,0,0,0,3L56.21,86.72a1.36,1.36,0,0,0,2.3,0,2.58,2.58,0,0,0,0-3Z',
@@ -10,18 +10,17 @@ const generellSliderSettings = {
   wrapAround: true,
 };
 
-const pageHeaderSliders = document.querySelectorAll('.ph-slider');
-pageHeaderSliders.forEach((slide) => {
-  new Flickity(slide, {
-    ...generellSliderSettings,
-    autoPlay: 6000,
+const createSlider = (sliders, additionalSettings = {}) => {
+  sliders.forEach((slider) => {
+    new Flickity(slider, {
+      ...generalSliderSettings,
+      ...additionalSettings,
+    });
   });
-});
+};
+
+const pageHeaderSliders = document.querySelectorAll('.ph-slider');
+createSlider(pageHeaderSliders, { autoPlay: 6000 });
 
 const pageBuilderSliders = document.querySelectorAll('.pb-carousel');
-pageBuilderSliders.forEach((slide) => {
-  new Flickity(slide, {
-    ...generellSliderSettings,
-    autoPlay: 8000,
-  });
-});
+createSlider(pageBuilderSliders, { autoPlay: 8000 });


### PR DESCRIPTION
See [the slider.js of ABC-Team](https://github.com/100herz/abc-team/blob/2408d660d1f62b8fc586ee69f2a0c6bdbb58f28a/src/js/plugins/slider.js) for a more complex example. There you can see the real benefit.

## Description of the code

### Function definition

```js
const createSlider = (sliders, additionalSettings = {}) => {
  sliders.forEach(slider => {
    new Flickity(slider, {
      ...generalSliderSettings,
      ...additionalSettings,
    })
  })
}
```

This function has two arguments:
1. `slider` as [`NodeListOf`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList)
1. _optional_ `additionalSettings` as [`Flickity.Options`](https://flickity.metafizzy.co/options.html) object

In the `forEach` loop we create - as before - the `Flickity` object. As the second argument, we combine the option from the `generalSliderSettings` and `additionalSettings`, which we have taken from our function definition, which overwrite the original once.

### Function call

```js
const pageHeaderSliders = document.querySelectorAll('.ph-slider');
createSlider(pageHeaderSliders, { autoPlay: 6000 });

// also possible is
const pageHeaderSliders = document.querySelectorAll('.ph-slider');
createSlider(pageHeaderSliders); // without the second parameter

// or shorter, but not so easy to recognize which slider is meant
createSlider(document.querySelectorAll('.ph-slider'));
```

---

Of course you can always ask me if something is unclear.